### PR TITLE
Add eslint v6 as peer dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepack": "yarn build"
   },
   "peerDependencies": {
-    "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0"
+    "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "@types/eslint": "4.16.0",


### PR DESCRIPTION
The plugin emits an error warning when used with the latest version of eslint. However, it works fine from my testing and this simply makes the warning go away. This would also require a new release at .0.4.1.


