### PR TITLE
no-duplicate-string should ignore 'use strict'

### DIFF
--- a/src/rules/no-duplicate-string.ts
+++ b/src/rules/no-duplicate-string.ts
@@ -46,8 +46,8 @@ const rule: Rule.RuleModule = {
           const stringContent = literal.value.trim();
 
           if (
+            stringContent.length > MIN_LENGTH &&
             !isExcludedByUsageContext(context, literal) &&
-            stringContent.length >= MIN_LENGTH &&
             !stringContent.match(NO_SEPARATOR_REGEXP)
           ) {
             const sameStringLiterals = literalsByValue.get(stringContent) || [];


### PR DESCRIPTION
...and alike statements, such as `'almost asm';`

This is a pragmatic approach to fix #127 
