### PR TITLE
Fix highlighted JSON error in README markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ npm install eslint-plugin-sonarjs -g         # or install globally
 
 * or enable only some rules manually:
 
-```json
+```javascript
 {
   "rules": {
     "sonarjs/cognitive-complexity": "error",
     "sonarjs/no-identical-expressions": "error"
-    // etc
+    // etc.
   }
 }
 ```


### PR DESCRIPTION
To avoid the "error" displayed below in readme (since comments are not allowed in JSON), we could replace ` ```json ` with ` ```javascript ` in markdown. 
<img width="445" alt="Capture d’écran 2019-12-30 à 09 02 05" src="https://user-images.githubusercontent.com/1575946/71573286-65acfd00-2ae3-11ea-9d4d-c2e8c040a098.png">

Also, `etc` has been replaced by `etc.` ([source](https://en.wikipedia.org/wiki/Et_cetera))
