### PR TITLE
feat: add `meta.type`

### DIFF
--- a/src/rules/cognitive-complexity.ts
+++ b/src/rules/cognitive-complexity.ts
@@ -44,6 +44,7 @@ type OptionalLocation = estree.SourceLocation | null | undefined;
 
 const rule: Rule.RuleModule = {
   meta: {
+    type: "suggestion",
     schema: [
       { type: "integer", minimum: 0 },
       {

--- a/src/rules/max-switch-cases.ts
+++ b/src/rules/max-switch-cases.ts
@@ -29,6 +29,7 @@ let maxSwitchCases = DEFAULT_MAX_SWITCH_CASES;
 
 const rule: Rule.RuleModule = {
   meta: {
+    type: "suggestion",
     schema: [
       {
         type: "integer",

--- a/src/rules/no-all-duplicated-branches.ts
+++ b/src/rules/no-all-duplicated-branches.ts
@@ -30,6 +30,9 @@ const MESSAGE_CONDITIONAL_EXPRESSION =
   'This conditional operation returns the same value whether the condition is "true" or "false".';
 
 const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+  },
   create(context: Rule.RuleContext) {
     return {
       IfStatement(node: estree.Node) {

--- a/src/rules/no-collapsible-if.ts
+++ b/src/rules/no-collapsible-if.ts
@@ -26,6 +26,7 @@ import { report, issueLocation } from "../utils/locations";
 
 const rule: Rule.RuleModule = {
   meta: {
+    type: "suggestion",
     schema: [
       {
         // internal parameter

--- a/src/rules/no-collection-size-mischeck.ts
+++ b/src/rules/no-collection-size-mischeck.ts
@@ -28,6 +28,9 @@ const CollectionLike = ["Array", "Map", "Set", "WeakMap", "WeakSet"];
 const CollectionSizeLike = ["length", "size"];
 
 const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+  },
   create(context: Rule.RuleContext) {
     const services = context.parserServices;
     const isTypeCheckerAvailable = isRequiredParserServices(services);

--- a/src/rules/no-duplicate-string.ts
+++ b/src/rules/no-duplicate-string.ts
@@ -32,6 +32,7 @@ const MESSAGE = "Define a constant instead of duplicating this literal {{times}}
 
 const rule: Rule.RuleModule = {
   meta: {
+    type: "suggestion",
     schema: [{ type: "integer", minimum: 2 }],
   },
 

--- a/src/rules/no-duplicated-branches.ts
+++ b/src/rules/no-duplicated-branches.ts
@@ -30,6 +30,7 @@ const MESSAGE = "This {{type}}'s code block is the same as the block for the {{t
 
 const rule: Rule.RuleModule = {
   meta: {
+    type: "problem",
     schema: [
       {
         // internal parameter

--- a/src/rules/no-element-overwrite.ts
+++ b/src/rules/no-element-overwrite.ts
@@ -37,6 +37,7 @@ const message = (index: string, line: string) =>
 
 const rule: Rule.RuleModule = {
   meta: {
+    type: "problem",
     schema: [
       {
         // internal parameter

--- a/src/rules/no-extra-arguments.ts
+++ b/src/rules/no-extra-arguments.ts
@@ -32,6 +32,7 @@ import { report, issueLocation, getMainFunctionTokenLocation, IssueLocation } fr
 
 const rule: Rule.RuleModule = {
   meta: {
+    type: "problem",
     schema: [
       {
         // internal parameter

--- a/src/rules/no-identical-conditions.ts
+++ b/src/rules/no-identical-conditions.ts
@@ -27,6 +27,7 @@ import { report, issueLocation } from "../utils/locations";
 
 const rule: Rule.RuleModule = {
   meta: {
+    type: "problem",
     schema: [
       {
         // internal parameter

--- a/src/rules/no-identical-expressions.ts
+++ b/src/rules/no-identical-expressions.ts
@@ -50,6 +50,7 @@ function isOneOntoOneShifting(node: BinaryExpression | LogicalExpression) {
 
 const rule: Rule.RuleModule = {
   meta: {
+    type: "problem",
     schema: [
       {
         // internal parameter

--- a/src/rules/no-identical-functions.ts
+++ b/src/rules/no-identical-functions.ts
@@ -30,6 +30,7 @@ const message = (line: string) =>
 
 const rule: Rule.RuleModule = {
   meta: {
+    type: "problem",
     schema: [
       {
         enum: ["sonar-runtime"],

--- a/src/rules/no-inverted-boolean-check.ts
+++ b/src/rules/no-inverted-boolean-check.ts
@@ -39,6 +39,7 @@ const invertedOperators: { [operator: string]: string } = {
 const rule: Rule.RuleModule = {
   meta: {
     fixable: "code",
+    type: "suggestion",
   },
   create(context: Rule.RuleContext) {
     return { UnaryExpression: (node: Node) => visitUnaryExpression(node as UnaryExpression, context) };

--- a/src/rules/no-one-iteration-loop.ts
+++ b/src/rules/no-one-iteration-loop.ts
@@ -24,6 +24,9 @@ import { Node, WhileStatement, ForStatement } from "estree";
 import { isContinueStatement, getParent } from "../utils/nodes";
 
 const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+  },
   create(context: Rule.RuleContext) {
     const loopingNodes: Set<Node> = new Set();
     const loops: Set<Node> = new Set();

--- a/src/rules/no-redundant-boolean.ts
+++ b/src/rules/no-redundant-boolean.ts
@@ -26,6 +26,9 @@ import { getParent, isBooleanLiteral, isIfStatement, isConditionalExpression } f
 const MESSAGE = "Remove the unnecessary boolean literal.";
 
 const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+  },
   create(context: Rule.RuleContext) {
     return {
       BinaryExpression(node: Node) {

--- a/src/rules/no-redundant-jump.ts
+++ b/src/rules/no-redundant-jump.ts
@@ -27,6 +27,9 @@ const message = "Remove this redundant jump.";
 const loops = "WhileStatement, ForStatement, DoWhileStatement, ForInStatement, ForOfStatement";
 
 const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+  },
   create(context: Rule.RuleContext) {
     function reportIfLastStatement(node: estree.ContinueStatement | estree.ReturnStatement) {
       const withArgument = node.type === "ContinueStatement" ? !!node.label : !!node.argument;

--- a/src/rules/no-same-line-conditional.ts
+++ b/src/rules/no-same-line-conditional.ts
@@ -30,6 +30,7 @@ interface SiblingIfStatement {
 
 const rule: Rule.RuleModule = {
   meta: {
+    type: "problem",
     schema: [
       {
         // internal parameter

--- a/src/rules/no-small-switch.ts
+++ b/src/rules/no-small-switch.ts
@@ -25,6 +25,9 @@ import { Node, SwitchStatement } from "estree";
 const MESSAGE = '"switch" statements should have at least 3 "case" clauses';
 
 const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+  },
   create(context: Rule.RuleContext) {
     return {
       SwitchStatement(node: Node) {

--- a/src/rules/no-unused-collection.ts
+++ b/src/rules/no-unused-collection.ts
@@ -27,6 +27,9 @@ import { collectionConstructor, writingMethods } from "../utils/collections";
 const message = "Either use this collection's contents or remove the collection.";
 
 const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+  },
   create(context: Rule.RuleContext) {
     return {
       "Program:exit": () => {

--- a/src/rules/no-use-of-empty-return-value.ts
+++ b/src/rules/no-use-of-empty-return-value.ts
@@ -52,6 +52,9 @@ function isReturnValueUsed(callExpr: Node, context: Rule.RuleContext) {
 }
 
 const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+  },
   create(context: Rule.RuleContext) {
     const callExpressionsToCheck: Map<Identifier, Function> = new Map();
     const functionsWithReturnValue: Set<Function> = new Set();

--- a/src/rules/no-useless-catch.ts
+++ b/src/rules/no-useless-catch.ts
@@ -27,6 +27,9 @@ import { areEquivalent } from "../utils/equivalence";
 const MESSAGE = "Add logic to this catch clause or eliminate it and rethrow the exception automatically.";
 
 const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+  },
   create(context: Rule.RuleContext) {
     return { CatchClause: (node: Node) => visitCatchClause(node as CatchClause, context) };
   },

--- a/src/rules/prefer-immediate-return.ts
+++ b/src/rules/prefer-immediate-return.ts
@@ -25,6 +25,7 @@ import { isReturnStatement, isThrowStatement, isIdentifier, isVariableDeclaratio
 
 const rule: Rule.RuleModule = {
   meta: {
+    type: "suggestion",
     fixable: "code",
   },
   create(context: Rule.RuleContext) {

--- a/src/rules/prefer-object-literal.ts
+++ b/src/rules/prefer-object-literal.ts
@@ -36,6 +36,9 @@ const MESSAGE =
   "Declare one or more properties of this object inside of the object literal syntax instead of using separate statements.";
 
 const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+  },
   create(context: Rule.RuleContext) {
     return {
       BlockStatement: (node: Node) => checkObjectInitialization((node as BlockStatement).body, context),

--- a/src/rules/prefer-single-boolean-return.ts
+++ b/src/rules/prefer-single-boolean-return.ts
@@ -24,6 +24,9 @@ import * as estree from "estree";
 import { isReturnStatement, isBlockStatement, isBooleanLiteral, isIfStatement, getParent } from "../utils/nodes";
 
 const rule: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+  },
   create(context: Rule.RuleContext) {
     return {
       IfStatement(node: estree.Node) {

--- a/src/rules/prefer-while.ts
+++ b/src/rules/prefer-while.ts
@@ -25,6 +25,7 @@ import * as estree from "estree";
 const rule: Rule.RuleModule = {
   meta: {
     fixable: "code",
+    type: "suggestion",
   },
   create(context: Rule.RuleContext) {
     return {


### PR DESCRIPTION
Besides adding clarity to the rule intent, with fixable rules one can use `eslint --fix-type` to fix rules of one type only: https://eslint.org/docs/user-guide/command-line-interface#fix-type

**Update**: now builds on #161. 