### PR TITLE
Add `meta.fixable` to fixable rules

### DIFF
--- a/src/rules/no-inverted-boolean-check.ts
+++ b/src/rules/no-inverted-boolean-check.ts
@@ -37,6 +37,9 @@ const invertedOperators: { [operator: string]: string } = {
 };
 
 const rule: Rule.RuleModule = {
+  meta: {
+    fixable: "code",
+  },
   create(context: Rule.RuleContext) {
     return { UnaryExpression: (node: Node) => visitUnaryExpression(node as UnaryExpression, context) };
   },

--- a/src/rules/prefer-while.ts
+++ b/src/rules/prefer-while.ts
@@ -23,6 +23,9 @@ import { Rule } from "eslint";
 import * as estree from "estree";
 
 const rule: Rule.RuleModule = {
+  meta: {
+    fixable: "code",
+  },
   create(context: Rule.RuleContext) {
     return {
       ForStatement(node: estree.Node) {


### PR DESCRIPTION
- Indicate rules that are fixable with `meta.fixable` property

Per the ESLint docs at https://eslint.org/docs/developer-guide/working-with-rules#rule-basics :

> Important: Without the fixable property, ESLint does not apply fixes even if the rule implements fix functions.
