### PR TITLE
Add `.ncurc.js`

### DIFF
--- a/.ncurc.js
+++ b/.ncurc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  // Whitelist all for checking besides `peer` which indicates
+  //   somewhat older versions of `eslint` we still support even
+  //   while our devDeps point to a more recent version
+  dep: "prod,dev,optional,bundle",
+};


### PR DESCRIPTION
- add ncurc.js to prevent `peerDependencies` auto-updating when running `ncu -u` (or `npm-check-updates`) to get dependencies updated

This is for use with the very helpful package https://github.com/tjunnone/npm-check-updates . Even if you are not using it, for those checking to see that your project's dependencies are using the latest stable versions, and creating PRs to bring them up to date, it can be helpful for us not to accidentally update your peerDeps (when running the `ncu -u` command).