### PR TITLE
Allow ESLint 7 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepack": "yarn build"
   },
   "peerDependencies": {
-    "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+    "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "@types/eslint": "6.1.3",


### PR DESCRIPTION
ESLint 7 has been out for a while now, and this plugin works fine with it.
