### PR TITLE
Ignore React functional components with fragment in cognitive-complexity

### DIFF
--- a/src/rules/cognitive-complexity.ts
+++ b/src/rules/cognitive-complexity.ts
@@ -300,7 +300,11 @@ const rule: Rule.RuleModule<string, Options> = {
 
     function visitReturnStatement({ argument }: TSESTree.ReturnStatement) {
       // top level function
-      if (enclosingFunctions.length === 1 && argument && (argument.type as any) === 'JSXElement') {
+      if (
+        enclosingFunctions.length === 1 &&
+        argument &&
+        ['JSXElement', 'JSXFragment'].includes(argument.type as any)
+      ) {
         reactFunctionalComponent.returnsJsx = true;
       }
     }

--- a/tests/rules/cognitive-complexity.test.ts
+++ b/tests/rules/cognitive-complexity.test.ts
@@ -491,6 +491,24 @@ ruleTester.run('cognitive-complexity', rule, {
       options: [0],
       errors: [message(1, { line: 2 }), message(1, { line: 3 })],
     },
+    {
+      code: `
+      const Welcome = () => {
+        const handleSomething = () => {
+          if (x) {} // +1
+        }
+        if (x) {} // +1
+        return (
+          <>
+            <h1>Hello, world</h1>
+            <p>cat</p>
+          </>
+        );
+      }`,
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      options: [0],
+      errors: [message(1, { line: 2 }), message(1, { line: 3 })],
+    },
   ],
 });
 


### PR DESCRIPTION
The changes made in https://github.com/SonarSource/eslint-plugin-sonarjs/commit/b0fada7a30c9317e35d87bf593cabb9c13fe7ab8
were not working for components, which return React.Fragment as a top-level element.