### PR TITLE
Rule S930: improve highlighting for no-extra-arguments

### DIFF
--- a/src/rules/no-extra-arguments.ts
+++ b/src/rules/no-extra-arguments.ts
@@ -32,6 +32,7 @@ import {
   issueLocation,
   getMainFunctionTokenLocation,
   IssueLocation,
+  toSecondaryLocation,
 } from '../utils/locations';
 import { Rule } from '../utils/types';
 
@@ -190,7 +191,7 @@ const rule: Rule.RuleModule = {
       // find actual extra arguments to highlight
       callExpr.arguments.forEach((argument, index) => {
         if (index >= paramLength) {
-          secondaryLocations.push(issueLocation(argument.loc, argument.loc, 'Extra argument'));
+          secondaryLocations.push(toSecondaryLocation(argument, 'Extra argument'));
         }
       });
       return secondaryLocations;

--- a/src/rules/no-extra-arguments.ts
+++ b/src/rules/no-extra-arguments.ts
@@ -179,11 +179,7 @@ const rule: Rule.RuleModule = {
       if (paramLength > 0) {
         const startLoc = functionNode.params[0].loc;
         const endLoc = functionNode.params[paramLength - 1].loc;
-        // defensive check as `loc` property may be undefined according to
-        // its type declaration
-        if (startLoc && endLoc) {
-          secondaryLocations.push(issueLocation(startLoc, endLoc, 'Formal parameters'));
-        }
+        secondaryLocations.push(issueLocation(startLoc, endLoc, 'Formal parameters'));
       } else {
         // as we're not providing parent node, `getMainFunctionTokenLocation` may return `undefined`
         const fnToken = getMainFunctionTokenLocation(functionNode, undefined, context);
@@ -193,7 +189,7 @@ const rule: Rule.RuleModule = {
       }
       // find actual extra arguments to highlight
       callExpr.arguments.forEach((argument, index) => {
-        if (index >= paramLength && argument.loc) {
+        if (index >= paramLength) {
           secondaryLocations.push(issueLocation(argument.loc, argument.loc, 'Extra argument'));
         }
       });

--- a/src/rules/no-extra-arguments.ts
+++ b/src/rules/no-extra-arguments.ts
@@ -164,13 +164,16 @@ const rule: Rule.RuleModule = {
         context,
         {
           message,
-          node: callExpr,
+          node: callExpr.callee,
         },
-        getSecondaryLocations(functionNode),
+        getSecondaryLocations(callExpr, functionNode),
       );
     }
 
-    function getSecondaryLocations(functionNode: TSESTree.FunctionLike) {
+    function getSecondaryLocations(
+      callExpr: TSESTree.CallExpression,
+      functionNode: TSESTree.FunctionLike,
+    ) {
       const paramLength = functionNode.params.length;
       const secondaryLocations: IssueLocation[] = [];
       if (paramLength > 0) {
@@ -188,6 +191,14 @@ const rule: Rule.RuleModule = {
           secondaryLocations.push(issueLocation(fnToken, fnToken, 'Formal parameters'));
         }
       }
+
+      // find actual extra arguments to highlight
+      callExpr.arguments.forEach((argument, index) => {
+        if (index >= paramLength && argument.loc) {
+          secondaryLocations.push(issueLocation(argument.loc, argument.loc, 'Excess parameter'));
+        }
+      });
+
       return secondaryLocations;
     }
   },

--- a/src/rules/no-extra-arguments.ts
+++ b/src/rules/no-extra-arguments.ts
@@ -191,14 +191,12 @@ const rule: Rule.RuleModule = {
           secondaryLocations.push(issueLocation(fnToken, fnToken, 'Formal parameters'));
         }
       }
-
       // find actual extra arguments to highlight
       callExpr.arguments.forEach((argument, index) => {
         if (index >= paramLength && argument.loc) {
-          secondaryLocations.push(issueLocation(argument.loc, argument.loc, 'Excess parameter'));
+          secondaryLocations.push(issueLocation(argument.loc, argument.loc, 'Extra argument'));
         }
       });
-
       return secondaryLocations;
     }
   },

--- a/src/utils/locations.ts
+++ b/src/utils/locations.ts
@@ -128,11 +128,11 @@ export function toEncodedMessage(
   return JSON.stringify(encodedMessage);
 }
 
-function toSecondaryLocation(
+export function toSecondaryLocation(
   locationHolder: TSESLint.AST.Token | TSESTree.Node,
   message?: string,
 ): IssueLocation {
-  const loc = locationHolder.loc!;
+  const loc = locationHolder.loc;
   return {
     message,
     column: loc.start.column,

--- a/tests/rules/no-extra-arguments.test.ts
+++ b/tests/rules/no-extra-arguments.test.ts
@@ -92,7 +92,7 @@ ruleTester.run('no-extra-arguments', rule, {
         function foo(p1, p2) {}
         //           ^^^^^^>
         foo(1, 2, 3);
-      //^^^       ^
+      //^^^      <^
       `,
       errors: [
         {

--- a/tests/rules/no-extra-arguments.test.ts
+++ b/tests/rules/no-extra-arguments.test.ts
@@ -98,7 +98,7 @@ ruleTester.run('no-extra-arguments', rule, {
         {
           message: encodedMessage(2, 3, [
             { line: 2, column: 21, endLine: 2, endColumn: 27, message: 'Formal parameters' },
-            { line: 4, column: 18, endLine: 4, endColumn: 19, message: 'Extra argument' },
+            { message: 'Extra argument', column: 18, line: 4, endColumn: 19, endLine: 4 },
           ]),
         },
       ],
@@ -126,7 +126,7 @@ ruleTester.run('no-extra-arguments', rule, {
         {
           message: encodedMessage(0, 1, [
             { line: 4, column: 18, endLine: 4, endColumn: 26, message: 'Formal parameters' },
-            { line: 2, column: 12, endLine: 2, endColumn: 13, message: 'Extra argument' },
+            { message: 'Extra argument', column: 12, line: 2, endColumn: 13, endLine: 2 },
           ]),
         },
       ],

--- a/tests/rules/no-extra-arguments.test.ts
+++ b/tests/rules/no-extra-arguments.test.ts
@@ -134,26 +134,6 @@ ruleTester.run('no-extra-arguments', rule, {
     },
     {
       code: `
-        function foo(arguments) {
-          console.log(arguments);
-        }
-        foo(1, 2);
-      `,
-      errors: [message(1, 2, { line: 5, column: 9, endColumn: 12 })],
-    },
-    {
-      code: `
-        function foo() {
-          let arguments = [3, 4];
-          console.log(arguments);
-        }
-        foo(1, 2);
-      `,
-      errors: [message(0, 2, { line: 6, column: 9, endColumn: 12 })],
-    },
-
-    {
-      code: `
         (function(p1, p2){
           doSomething1;
           doSomething2;

--- a/tests/rules/no-extra-arguments.test.ts
+++ b/tests/rules/no-extra-arguments.test.ts
@@ -83,8 +83,8 @@ ruleTester.run('no-extra-arguments', rule, {
         foo(1, 2, 3, 4);
       `,
       errors: [
-        message(2, 3, { line: 3, column: 9, endColumn: 21 }),
-        message(2, 4, { line: 4, column: 9, endColumn: 24 }),
+        message(2, 3, { line: 3, column: 9, endColumn: 12 }),
+        message(2, 4, { line: 4, column: 9, endColumn: 12 }),
       ],
     },
     {
@@ -92,12 +92,13 @@ ruleTester.run('no-extra-arguments', rule, {
         function foo(p1, p2) {}
         //           ^^^^^^>
         foo(1, 2, 3);
-      //^^^^^^^^^^^^
+      //^^^       ^
       `,
       errors: [
         {
           message: encodedMessage(2, 3, [
             { line: 2, column: 21, endLine: 2, endColumn: 27, message: 'Formal parameters' },
+            { line: 4, column: 18, endLine: 4, endColumn: 19, message: 'Excess parameter' },
           ]),
         },
       ],
@@ -110,12 +111,12 @@ ruleTester.run('no-extra-arguments', rule, {
         }
         foo(1);
       `,
-      errors: [message(0, 1, { line: 5, column: 9, endColumn: 15 })],
+      errors: [message(0, 1, { line: 5, column: 9, endColumn: 12 })],
     },
     {
       code: `
         foo(1);
-      //^^^^^^
+      //    ^
         var foo = function() {
           //      ^^^^^^^^>
           console.log('hello');
@@ -125,10 +126,30 @@ ruleTester.run('no-extra-arguments', rule, {
         {
           message: encodedMessage(0, 1, [
             { line: 4, column: 18, endLine: 4, endColumn: 26, message: 'Formal parameters' },
+            { line: 2, column: 12, endLine: 2, endColumn: 13, message: 'Excess parameter' },
           ]),
         },
       ],
       options: ['sonar-runtime'],
+    },
+    {
+      code: `
+        function foo(arguments) {
+          console.log(arguments);
+        }
+        foo(1, 2);
+      `,
+      errors: [message(1, 2, { line: 5, column: 9, endColumn: 12 })],
+    },
+    {
+      code: `
+        function foo() {
+          let arguments = [3, 4];
+          console.log(arguments);
+        }
+        foo(1, 2);
+      `,
+      errors: [message(0, 2, { line: 6, column: 9, endColumn: 12 })],
     },
 
     {
@@ -138,7 +159,7 @@ ruleTester.run('no-extra-arguments', rule, {
           doSomething2;
         })(1, 2, 3);
       `,
-      errors: [message(2, 3, { line: 2, column: 9, endLine: 5, endColumn: 20 })],
+      errors: [message(2, 3, { line: 2, column: 10, endLine: 5, endColumn: 10 })],
     },
     {
       code: `
@@ -146,7 +167,7 @@ ruleTester.run('no-extra-arguments', rule, {
           return a + b;
         }(1, 2, 3);
       `,
-      errors: [message(2, 3, { line: 2, column: 17, endLine: 4, endColumn: 19 })],
+      errors: [message(2, 3, { line: 2, column: 17, endLine: 4, endColumn: 10 })],
     },
     {
       code: `
@@ -154,14 +175,14 @@ ruleTester.run('no-extra-arguments', rule, {
           return a + b;
         })(1, 2, 3);
       `,
-      errors: [message(2, 3, { line: 2, column: 9, endLine: 4, endColumn: 20 })],
+      errors: [message(2, 3, { line: 2, column: 10, endLine: 4, endColumn: 10 })],
     },
     {
       code: `
         let arrow_function = (a, b) => {};
         arrow_function(1, 2, 3);
       `,
-      errors: [message(2, 3, { line: 3, column: 9, endColumn: 32 })],
+      errors: [message(2, 3, { line: 3, column: 9, endColumn: 23 })],
     },
   ],
 });
@@ -176,7 +197,7 @@ ruleTesterScript.run('no-extra-arguments script', rule, {
         }
         foo(1, 2);
       `,
-      errors: [message(1, 2, { line: 5, column: 9, endColumn: 18 })],
+      errors: [message(1, 2, { line: 5, column: 9, endColumn: 12 })],
     },
     {
       code: `
@@ -186,7 +207,7 @@ ruleTesterScript.run('no-extra-arguments script', rule, {
         }
         foo(1, 2);
       `,
-      errors: [message(0, 2, { line: 6, column: 9, endColumn: 18 })],
+      errors: [message(0, 2, { line: 6, column: 9, endColumn: 12 })],
     },
   ],
 });

--- a/tests/rules/no-extra-arguments.test.ts
+++ b/tests/rules/no-extra-arguments.test.ts
@@ -98,7 +98,7 @@ ruleTester.run('no-extra-arguments', rule, {
         {
           message: encodedMessage(2, 3, [
             { line: 2, column: 21, endLine: 2, endColumn: 27, message: 'Formal parameters' },
-            { line: 4, column: 18, endLine: 4, endColumn: 19, message: 'Excess parameter' },
+            { line: 4, column: 18, endLine: 4, endColumn: 19, message: 'Extra argument' },
           ]),
         },
       ],
@@ -126,7 +126,7 @@ ruleTester.run('no-extra-arguments', rule, {
         {
           message: encodedMessage(0, 1, [
             { line: 4, column: 18, endLine: 4, endColumn: 26, message: 'Formal parameters' },
-            { line: 2, column: 12, endLine: 2, endColumn: 13, message: 'Excess parameter' },
+            { line: 2, column: 12, endLine: 2, endColumn: 13, message: 'Extra argument' },
           ]),
         },
       ],


### PR DESCRIPTION
Fixes #178 

The ticket mentions customising the message of the primary location with the function name depending on the callee type, which this user contribution does not include. I think we don't need to go that far as the location-based highlighting of an issue would be enough.