### PR TITLE
fix: ruleFileName ends with .js after compilation

### DIFF
--- a/src/utils/docs-url.ts
+++ b/src/utils/docs-url.ts
@@ -21,6 +21,6 @@
 import * as path from 'path';
 
 export default function docsUrl(ruleFileName: string) {
-  const ruleMarkdownDoc = path.basename(ruleFileName).replace('.ts', '.md');
+  const ruleMarkdownDoc = path.basename(ruleFileName).replace(/\.[jt]s$/, '.md');
   return `https://github.com/SonarSource/eslint-plugin-sonarjs/blob/master/docs/rules/${ruleMarkdownDoc}`;
 }


### PR DESCRIPTION
Fixes an issue with eslint in vscode:

![image](https://user-images.githubusercontent.com/48261497/125259614-c4ba1780-e2ff-11eb-8fd6-2c411dfce328.png)
![image](https://user-images.githubusercontent.com/48261497/125259661-cf74ac80-e2ff-11eb-8524-a083cb188d1c.png)

