### PR TITLE
Fix link to docs in rule meta

### DIFF
--- a/src/utils/docs-url.ts
+++ b/src/utils/docs-url.ts
@@ -21,6 +21,6 @@
 import * as path from 'path';
 
 export default function docsUrl(ruleFileName: string) {
-  const ruleMarkdownDoc = path.basename(ruleFileName).replace('.ts', '.md');
+  const ruleMarkdownDoc = path.basename(ruleFileName).replace(/\.[jt]s$/, '.md');
   return `https://github.com/SonarSource/eslint-plugin-sonarjs/blob/master/docs/rules/${ruleMarkdownDoc}`;
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -44,6 +44,8 @@ it('should document all rules', () => {
   existingRules.forEach(rule => {
     expect(README.includes(rule)).toBe(true);
     expect(fs.existsSync(`${root}/docs/rules/${rule}.md`)).toBe(true);
-    expect(rules[rule].meta.docs).toBeDefined();
+    expect(rules[rule].meta.docs.url).toBe(
+      `https://github.com/SonarSource/eslint-plugin-sonarjs/blob/master/docs/rules/${rule}.md`,
+    );
   });
 });


### PR DESCRIPTION
ruleFileName ends with .js after compilation

Unfortunately we didn't find a way to unit test the fixed problem