### PR TITLE
Improve 'prefer-immediate-return': ignore when returned variable has a declared type

### DIFF
--- a/src/rules/prefer-immediate-return.ts
+++ b/src/rules/prefer-immediate-return.ts
@@ -113,7 +113,7 @@ const rule: Rule.RuleModule = {
     function getOnlyDeclaredVariable(node: TSESTree.Statement) {
       if (isVariableDeclaration(node) && node.declarations.length === 1) {
         const { id, init } = node.declarations[0];
-        if (isIdentifier(id) && init) {
+        if (isIdentifier(id) && init && !id.typeAnnotation) {
           return { id, init };
         }
       }

--- a/tests/rules/prefer-immediate-return.test.ts
+++ b/tests/rules/prefer-immediate-return.test.ts
@@ -145,6 +145,14 @@ ruleTester.run('prefer-immediate-return', rule, {
     },
     {
       code: `
+        function variable_has_type_annotation() {
+          let foo: number = 1;
+          return foo;
+        }
+      `,
+    },
+    {
+      code: `
         function variable_is_used() {
           var bar = {
             doSomethingElse(p) {},


### PR DESCRIPTION
Fixes #274
