### PR TITLE
fix prefer-single-boolean-return: catch when nextNode is `ReturnStatement`

### DIFF
--- a/docs/rules/no-empty-collection.md
+++ b/docs/rules/no-empty-collection.md
@@ -11,5 +11,5 @@ if (strings.includes("foo")) {}  // Noncompliant
 
 for (str of strings) {}  // Noncompliant
 
-strings.forEach(str =&gt; doSomething(str)); // Noncompliant
+strings.forEach(str => doSomething(str)); // Noncompliant
 ```

--- a/docs/rules/prefer-single-boolean-return.md
+++ b/docs/rules/prefer-single-boolean-return.md
@@ -1,6 +1,6 @@
 # prefer-single-boolean-return
 
-Return of boolean literal statements wrapped into `if-then-else` ones should be simplified.
+Return of boolean literal statements should be simplified.
 
 ## Noncompliant Code Example
 
@@ -10,6 +10,15 @@ if (expression) {
 } else {
   return false;
 }
+```
+
+or
+
+```javascript
+if (expression) {
+  return true;
+}
+return false;
 ```
 
 ## Compliant Solution

--- a/tests/rules/prefer-single-boolean-return.test.ts
+++ b/tests/rules/prefer-single-boolean-return.test.ts
@@ -186,5 +186,40 @@ ruleTester.run('prefer-single-boolean-return', rule, {
         },
       ],
     },
+    {
+      code: `
+        function fn() {
+          if (foo) {
+            if (something) {
+              return true
+            }
+            return false
+          }
+
+          if (bar) {
+            if (something) {
+              return false
+            }
+            return true
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'replaceIfThenElseByReturn',
+          line: 4,
+          column: 13,
+          endLine: 6,
+          endColumn: 14,
+        },
+        {
+          messageId: 'replaceIfThenElseByReturn',
+          line: 11,
+          column: 13,
+          endLine: 13,
+          endColumn: 14,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
fix https://github.com/SonarSource/eslint-plugin-sonarjs/issues/316