### PR TITLE
Feature/add recommended warning configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ npm install eslint-plugin-sonarjs -g         # or install globally
 }
 ```
 
+* or add `plugin:sonarjs/recommended-warn` to enable warnings for all recommended rules:
+
+```json
+{
+  "extends": ["plugin:sonarjs/recommended-warn"]
+}
+```
+
 * or enable only some rules manually:
 
 ```javascript
@@ -121,15 +129,16 @@ npm install eslint-plugin-sonarjs -g         # or install globally
   }
 }
 ```
+
 * To enable all rules of this plugin, use `@typescript-eslint/parser` as a parser for ESLint ([like we do](https://github.com/SonarSource/eslint-plugin-sonarjs/blob/6e06d59a233e07b28fbbd6398e08b9b0c63b18f9/.eslintrc.js#L4)) and set the [parserOptions.project](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser#parseroptionsproject) option. Thanks to it, type information is available, which is beneficial or even essential for some rules.
 
 ## Available Configurations
 
-This plugin provides only `recommended` configuration. Almost all rules are activated in this profile with a few exceptions (check `disabled` tag in the rules list). `recommended` configuration activates rules with `error` severity. 
+This plugin provides only the `recommended` and `recommended-warn` configurations. Almost all rules are activated in these profiles with a few exceptions (check `disabled` tag in the rules list). `recommended` configuration activates rules with `error` severity. `recommended-warn` configuration activates rules with `warn` severity.
 
 ## ESLint and Sonar
 
-This plugin exposes to ESLint users a subset of JS/TS rules from Sonar-* products (aka [SonarJS](https://github.com/SonarSource/SonarJS)). We extracted the rules which are not available in ESLint core or other ESLint plugins to be beneficial for ESLint community. 
+This plugin exposes to ESLint users a subset of JS/TS rules from Sonar-* products (aka [SonarJS](https://github.com/SonarSource/SonarJS)). We extracted the rules which are not available in ESLint core or other ESLint plugins to be beneficial for ESLint community.
 
 If you are a [SonarQube](https://www.sonarqube.org) or [SonarCloud](https://sonarcloud.io) user, to lint your code locally, we suggest to use [SonarLint](https://www.sonarlint.org) IDE extension (available for VSCode, JetBrains IDEs and Eclipse). You can connect SonarLint to your SonarQube/SonarCloud project to synchronize rules configuration, issue statuses, etc.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@
  */
 import type { TSESLint } from '@typescript-eslint/experimental-utils';
 
+type Configuration = TSESLint.Linter.Config & { plugins: string[] };
+
 const sonarjsRules: string[] = [
   'cognitive-complexity',
   'elseif-without-else',
@@ -56,18 +58,22 @@ const sonarjsRules: string[] = [
 
 const sonarjsRuleModules: { [key: string]: any } = {};
 
-const configs: { recommended: TSESLint.Linter.Config & { plugins: string[] } } = {
+const configs: { recommended: Configuration; 'recommended-warn': Configuration } = {
   recommended: { plugins: ['sonarjs'], rules: {} },
+  'recommended-warn': { plugins: ['sonarjs'], rules: {} },
 };
 
 sonarjsRules.forEach(rule => {
   sonarjsRuleModules[rule] = require(`./rules/${rule}`);
+
   const {
     meta: {
       docs: { recommended },
     },
   } = sonarjsRuleModules[rule];
+
   configs.recommended.rules![`sonarjs/${rule}`] = recommended === false ? 'off' : recommended;
+  configs['recommended-warn'].rules![`sonarjs/${rule}`] = recommended === false ? 'off' : 'warn';
 });
 
 export { sonarjsRuleModules as rules, configs };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -31,6 +31,13 @@ it('should declare all rules in recommended config', () => {
   expect(Object.keys(configs.recommended.rules!)).toHaveLength(existingRules.length);
 });
 
+it('should declare all rules in recommended-warn config', () => {
+  existingRules.forEach(rule => {
+    expect(configs['recommended-warn'].rules).toHaveProperty(`sonarjs/${rule}`);
+  });
+  expect(Object.keys(configs['recommended-warn'].rules!)).toHaveLength(existingRules.length);
+});
+
 it('should declare all rules', () => {
   existingRules.forEach(rule => {
     expect(rules).toHaveProperty(rule);


### PR DESCRIPTION
Resolves #166, resolves #283

This PR adds the 'recommended-warn' configuration to the plugin, which enables all recommended rules with severity 'warn'. I've also added a test case and updated the docs to reflect the change. Let me know if any additional changes should be made.

Thanks for an amazing plugin. Cheers.