### PR TITLE
Improvement/hoc react functional modules

### DIFF
--- a/src/rules/cognitive-complexity.ts
+++ b/src/rules/cognitive-complexity.ts
@@ -335,6 +335,12 @@ const rule: TSESLint.RuleModule<string, (number | 'metric' | 'sonar-runtime')[]>
         return checkFirstLetter(parent.id.name);
       }
 
+      const { parent: upperParent } = parent as TSESTree.FunctionLike;
+
+      if (upperParent && upperParent.type === 'VariableDeclarator' && upperParent.id.type === 'Identifier') {
+        return checkFirstLetter(upperParent.id.name);
+      }
+
       return false;
     }
 

--- a/tests/rules/cognitive-complexity.test.ts
+++ b/tests/rules/cognitive-complexity.test.ts
@@ -500,22 +500,17 @@ ruleTester.run('cognitive-complexity', rule, {
     },
     {
       code: `
-      const Welcome = () => {
+      const Welcome = memo(() => {
         const handleSomething = () => {
           if (x) {} // +1
         }
         if (x) {} // +1
-        return (
-          <>
-            <h1>Hello, world</h1>
-            <p>cat</p>
-          </>
-        );
-      }`,
+        return <h1>Hello, world</h1>;
+      })`,
       parserOptions: { ecmaFeatures: { jsx: true } },
       options: [0],
       errors: [message(1, { line: 2 }), message(1, { line: 3 })],
-    },
+    }
   ],
 });
 

--- a/tests/rules/cognitive-complexity.test.ts
+++ b/tests/rules/cognitive-complexity.test.ts
@@ -492,7 +492,12 @@ ruleTester.run('cognitive-complexity', rule, {
           if (x) {} // +1
         }
         if (x) {} // +1
-        return <h1>Hello, world</h1>;
+        return (
+          <>
+            <h1>Hello, world</h1>
+            <p>cat</p>
+          </>
+        );
       }`,
       parserOptions: { ecmaFeatures: { jsx: true } },
       options: [0],
@@ -505,7 +510,12 @@ ruleTester.run('cognitive-complexity', rule, {
           if (x) {} // +1
         }
         if (x) {} // +1
-        return <h1>Hello, world</h1>;
+        return (
+          <>
+            <h1>Hello, world</h1>
+            <p>cat</p>
+          </>
+        );
       })`,
       parserOptions: { ecmaFeatures: { jsx: true } },
       options: [0],


### PR DESCRIPTION
## Description

Solution in relevant pull request complements one of previous fixes related to the React functional components: https://github.com/SonarSource/eslint-plugin-sonarjs/pull/219

## Related Issues

Fix that included in mentioned above PR resolves issue about cognitive complexity score redundancy when using React functional components with additional score for nested if else condition inside of functional component methods. It works as expected, but the problem comes up when we are wrapping our functional component with HOC - in my case it was memoization function which are often used inline - this leaded to same issue with redundant +1 score for nested conditions in methods.

For fixing that, I've decided to look for a parent node name with additionally considering if we are returning JSX element/fragment to properly check is that a functional component or not.

## Tests

I added the following test in cognitive complexity rule tester:

```
 {
      code: `
      const Welcome = memo(() => {
        const handleSomething = () => {
          if (x) {} // +1
        }
        if (x) {} // +1
        return <h1>Hello, world</h1>;
      })`,
      parserOptions: { ecmaFeatures: { jsx: true } },
      options: [0],
      errors: [message(1, { line: 2 }), message(1, { line: 3 })],
    }
```

Test Suites: 34 passed, 34 total
Tests:       561 passed, 561 total
Snapshots:   0 total
Time:        6.116 s
