### PR TITLE
Fix S17647(`no-identical-expressions`): Consider bigint for 1bit shifting as valid

### DIFF
--- a/src/rules/no-identical-expressions.ts
+++ b/src/rules/no-identical-expressions.ts
@@ -53,7 +53,7 @@ function hasIdentifierOperands(node: TSESTree.BinaryExpression | TSESTree.Logica
 }
 
 function isOneOntoOneShifting(node: TSESTree.BinaryExpression | TSESTree.LogicalExpression) {
-  return node.operator === '<<' && isLiteral(node.left) && node.left.value === 1;
+  return node.operator === '<<' && isLiteral(node.left) && (node.left.value === 1 || node.left.value === 1n);
 }
 
 const message =

--- a/src/rules/no-identical-expressions.ts
+++ b/src/rules/no-identical-expressions.ts
@@ -53,7 +53,11 @@ function hasIdentifierOperands(node: TSESTree.BinaryExpression | TSESTree.Logica
 }
 
 function isOneOntoOneShifting(node: TSESTree.BinaryExpression | TSESTree.LogicalExpression) {
-  return node.operator === '<<' && isLiteral(node.left) && (node.left.value === 1 || node.left.value === 1n);
+  return (
+    node.operator === '<<' &&
+    isLiteral(node.left) &&
+    (node.left.value === 1 || node.left.value === 1n)
+  );
 }
 
 const message =

--- a/tests/rules/no-identical-expressions.test.ts
+++ b/tests/rules/no-identical-expressions.test.ts
@@ -23,6 +23,7 @@ import rule = require('../../src/rules/no-identical-expressions');
 ruleTester.run('no-identical-expressions', rule, {
   valid: [
     { code: `1 << 1;` },
+    { code: `1n << 1n;` },
     { code: `foo(), foo();` },
     { code: `if (Foo instanceof Foo) { }` },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2020",
     "module": "commonjs",
     "lib": ["es2017"],
     "strict": true,


### PR DESCRIPTION
Fixes #399 