### PR TITLE
Fix FP S2428 (`prefer-object-literal`): Ignore circular reference assignments

### DIFF
--- a/ruling/snapshots/prefer-object-literal
+++ b/ruling/snapshots/prefer-object-literal
@@ -9,7 +9,6 @@ src/brackets/src/extensibility/ExtensionManager.js: 313
 src/brackets/src/extensions/default/HealthData/HealthDataManager.js: 53
 src/brackets/src/extensions/default/InlineColorEditor/ColorEditor.js: 557,570,582
 src/brackets/src/extensions/default/JavaScriptRefactoring/RefactoringUtils.js: 365
-src/jest/packages/pretty-format/perf/test.js: 182
 src/jquery/external/sinon/sinon.js: 4500
 src/reveal.js/plugin/search/search.js: 165
 src/spectrum/api/models/user.js: 407

--- a/src/rules/prefer-object-literal.ts
+++ b/src/rules/prefer-object-literal.ts
@@ -69,8 +69,8 @@ function checkObjectInitialization(
     const objectDeclaration = getObjectDeclaration(statements[index]);
     // eslint-disable-next-line sonarjs/no-collapsible-if
     if (objectDeclaration && isIdentifier(objectDeclaration.id)) {
-      const stmt = statements[index + 1];
-      if (isPropertyAssignment(stmt, objectDeclaration.id, context.getSourceCode())) {
+      const nextStmt = statements[index + 1];
+      if (isPropertyAssignment(nextStmt, objectDeclaration.id, context.getSourceCode())) {
         context.report({ messageId: 'declarePropertiesInsideObject', node: objectDeclaration });
       }
     }

--- a/tests/rules/prefer-object-literal.test.ts
+++ b/tests/rules/prefer-object-literal.test.ts
@@ -75,6 +75,11 @@ ruleTester.run('prefer-literal', rule, {
     {
       code: `var x = {a: 2}; x.b = 5;`,
     },
+    {
+      code: `
+      const O = {};
+      O.self = O;`,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #391 
