### PR TITLE
Update README: Plugin now requires Node.js 14 or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Code Smells, or maintainability issues, are raised for places of code which migh
 
 ## Prerequisites
 
-* Node.js (>=12.x).
+* Node.js (>=14.x).
 * ESLint 5.x, 6.x, 7.x or 8.x (peer dependency for the plugin).
 
 ## Usage


### PR DESCRIPTION
Relates to https://github.com/SonarSource/eslint-plugin-sonarjs/issues/433