### PR TITLE
Fix FP 3699 (no-use-of-empty-return-values) to handle ambient functions

### DIFF
--- a/scripts/test-ci.sh
+++ b/scripts/test-ci.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # variable is set in dockerfile
 if [ "${SONARCLOUD_ANALYSIS:-}" == "true" ]; then
   echo 'Running tests with coverage and reporter'
-  npm run test -- --coverage --testResultsProcessor jest-sonar-reporter
+  npm run test -- --coverage --testResultsProcessor --maxWorkers=50% jest-sonar-reporter
 else
   echo 'Running tests'
   npm run test

--- a/scripts/test-ci.sh
+++ b/scripts/test-ci.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # variable is set in dockerfile
 if [ "${SONARCLOUD_ANALYSIS:-}" == "true" ]; then
   echo 'Running tests with coverage and reporter'
-  npm run test -- --coverage --testResultsProcessor --maxWorkers=50% jest-sonar-reporter
+  npm run test -- --maxWorkers=50% --coverage --testResultsProcessor jest-sonar-reporter
 else
   echo 'Running tests'
   npm run test

--- a/src/rules/no-use-of-empty-return-value.ts
+++ b/src/rules/no-use-of-empty-return-value.ts
@@ -26,6 +26,7 @@ import docsUrl from '../utils/docs-url';
 const EMPTY_RETURN_VALUE_KEYWORDS = new Set<TSESTree.AST_NODE_TYPES>([
   TSESTree.AST_NODE_TYPES.TSVoidKeyword,
   TSESTree.AST_NODE_TYPES.TSNeverKeyword,
+  TSESTree.AST_NODE_TYPES.TSUndefinedKeyword,
 ]);
 
 function isReturnValueUsed(callExpr: TSESTree.Node) {

--- a/src/rules/no-use-of-empty-return-value.ts
+++ b/src/rules/no-use-of-empty-return-value.ts
@@ -139,7 +139,10 @@ const rule: TSESLint.RuleModule<string, string[]> = {
 
       TSDeclareFunction(node: TSESTree.Node) {
         const declareFunction = node as TSESTree.TSDeclareFunction;
-        if (declareFunction.returnType?.typeAnnotation.type && !EMPTY_RETURN_VALUE_KEYWORDS.has(declareFunction.returnType?.typeAnnotation.type)) {
+        if (
+          declareFunction.returnType?.typeAnnotation.type &&
+          !EMPTY_RETURN_VALUE_KEYWORDS.has(declareFunction.returnType?.typeAnnotation.type)
+        ) {
           functionsWithReturnValue.add(declareFunction);
         }
       },

--- a/tests/rules/no-use-of-empty-return-value.test.ts
+++ b/tests/rules/no-use-of-empty-return-value.test.ts
@@ -73,7 +73,6 @@ ruleTester.run('no-use-of-empty-return-value', rule, {
     invalid('declare function noReturn(): never; let x = noReturn();'),
     invalid('declare function noReturn(): void; let x = noReturn();'),
     invalid('declare function noReturn(): undefined; let x = noReturn();'),
-    invalid('let noReturn = () => {}; let x = noReturn();'),
   ],
 });
 

--- a/tests/rules/no-use-of-empty-return-value.test.ts
+++ b/tests/rules/no-use-of-empty-return-value.test.ts
@@ -51,6 +51,8 @@ ruleTester.run('no-use-of-empty-return-value', rule, {
     },
     { code: 'function* noReturn() { yield 1; } noReturn().next();' },
     { code: 'function* noReturn() { yield 1; } noReturn();' },
+    { code: 'declare function withReturn(): number; let x = withReturn();' },
+    { code: 'declare function withReturn(): undefined; let x = withReturn();' },
   ],
   invalid: [
     invalidPrefixWithFunction('console.log(noReturn());'),
@@ -69,6 +71,8 @@ ruleTester.run('no-use-of-empty-return-value', rule, {
     ),
     invalid('var funcExpr = function noReturn () { 1; console.log(noReturn()); };'),
     invalid('var noReturn = () => { var x = () => {return 1}  }; x = noReturn();'),
+    invalid('declare function noReturn(): never; let x = noReturn();'),
+    invalid('declare function noReturn(): void; let x = noReturn();'),
   ],
 });
 

--- a/tests/rules/no-use-of-empty-return-value.test.ts
+++ b/tests/rules/no-use-of-empty-return-value.test.ts
@@ -52,7 +52,6 @@ ruleTester.run('no-use-of-empty-return-value', rule, {
     { code: 'function* noReturn() { yield 1; } noReturn().next();' },
     { code: 'function* noReturn() { yield 1; } noReturn();' },
     { code: 'declare function withReturn(): number; let x = withReturn();' },
-    { code: 'declare function withReturn(): undefined; let x = withReturn();' },
   ],
   invalid: [
     invalidPrefixWithFunction('console.log(noReturn());'),
@@ -73,6 +72,8 @@ ruleTester.run('no-use-of-empty-return-value', rule, {
     invalid('var noReturn = () => { var x = () => {return 1}  }; x = noReturn();'),
     invalid('declare function noReturn(): never; let x = noReturn();'),
     invalid('declare function noReturn(): void; let x = noReturn();'),
+    invalid('declare function noReturn(): undefined; let x = noReturn();'),
+    invalid('let noReturn = () => {}; let x = noReturn();'),
   ],
 });
 


### PR DESCRIPTION
Fixes https://github.com/SonarSource/SonarJS/issues/4579

This adds support for TSDeclareFunction function declaration. We consider 2 return types to be with no value: Void and Never.

Also, as part of this merge request, I update the rule to use TSESTree.AST_NODE_TYPES enum instead of strings.