### PR TITLE
Make no-unused-collection not trigger if writing to elements of said collection

### DIFF
--- a/src/rules/no-unused-collection.ts
+++ b/src/rules/no-unused-collection.ts
@@ -184,10 +184,7 @@ function isElementWrite(statement: TSESTree.ExpressionStatement, ref: TSESLint.S
 }
 
 function isMemberExpressionReference(lhs: TSESTree.Node, ref: TSESLint.Scope.Reference): boolean {
-  return (
-    lhs.type === 'MemberExpression' &&
-    (isReferenceTo(ref, lhs.object))
-  );
+  return lhs.type === 'MemberExpression' && isReferenceTo(ref, lhs.object);
 }
 
 function isIdentifier(node: TSESTree.Node, ...values: string[]): node is TSESTree.Identifier {

--- a/src/rules/no-unused-collection.ts
+++ b/src/rules/no-unused-collection.ts
@@ -186,7 +186,7 @@ function isElementWrite(statement: TSESTree.ExpressionStatement, ref: TSESLint.S
 function isMemberExpressionReference(lhs: TSESTree.Node, ref: TSESLint.Scope.Reference): boolean {
   return (
     lhs.type === 'MemberExpression' &&
-    (isReferenceTo(ref, lhs.object) || isMemberExpressionReference(lhs.object, ref))
+    (isReferenceTo(ref, lhs.object))
   );
 }
 

--- a/tests/rules/no-unused-collection.test.ts
+++ b/tests/rules/no-unused-collection.test.ts
@@ -34,7 +34,7 @@ function invalidTest(code: string) {
   };
 }
 
-ruleTester.run('Primitive return types should be used.', rule, {
+ruleTester.run('Collection contents should be used', rule, {
   valid: [
     {
       code: `
@@ -169,6 +169,13 @@ ruleTester.run('Primitive return types should be used.', rule, {
     {
       code: `export const collection = new Map()`,
     },
+    {
+      code: `
+        const a = {foo: false};
+        const xs = [a];
+        xs[0].foo = true;
+      `,
+    },
   ],
   invalid: [
     {
@@ -195,11 +202,6 @@ ruleTester.run('Primitive return types should be used.', rule, {
     invalidTest(`function nok2() {
           let arrayConstructor = new Array(); // Noncompliant
           arrayConstructor[1] = 42;
-      }
-      `),
-    invalidTest(`function nok2_1() {
-          let arrayConstructor = new Array(); // Noncompliant
-          arrayConstructor[1][2] = 42;
       }
       `),
     invalidTest(`function nok3() {


### PR DESCRIPTION
Fixes #449

As in the described issue, when accessing a collection items and performing a write on them, we can consider the collection as being used.

With removing the recursive call, we will now allow for code like:

let a = Array();
a[1][2] = 3; // mutates the underlying object, but a is being read.

