### PR TITLE
Bump the project manifest version to 0.25.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-sonarjs",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "SonarJS rules for ESLint",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
The release process uses the project manifest as the package manifest, so we need to change the version there to allow the package to be published.