### PR TITLE
Bump to version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-sonarjs",
-  "version": "0.26.0",
+  "version": "1.0.0",
   "description": "SonarJS rules for ESLint",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=eslint-plugin-sonarjs
 sonar.projectName=eslint-plugin-sonarjs
 sonar.projectDescription=SonarJS rules for ESLint
 
-sonar.projectVersion=0.26.0
+sonar.projectVersion=1.0.0
 
 sonar.links.homepage=https://github.com/SonarSource/eslint-plugin-sonarjs
 sonar.links.ci=https://travis-ci.org/SonarSource/eslint-plugin-sonarjs


### PR DESCRIPTION
As we've updated the plugin to work with the latest eslint v9 version, and dropping support for eslint 5, 6 and 7. Let us bring it to a new major version.