### PR TITLE
Increase node version on release from Node 12 -> 18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 18
       - run: mv .github/workflows/.npmrc .npmrc
       - name: Publish npm package
         env:


### PR DESCRIPTION
With the updates to the packages we use, running a release fails - https://github.com/SonarSource/eslint-plugin-sonarjs/actions/runs/8936694762 . 

Husky v9.0.11 requires Node >= 18, let us increase it to try.

Adding @julien-carsique-sonarsource - as you already looked at our pipelines before on https://sonarsource.atlassian.net/browse/BUILD-4742 . I'm not sure how to test this change other than testing in production. In the ticket, you mention all of the steps that we are using in jfrog are also deprecated, so maybe it would be a good time to update them?