### PR TITLE
feat: add `name` to current recommended config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ export const rules = {
 
 const recommendedLegacyConfig: TSESLint.Linter.ConfigType = { plugins: ['sonarjs'], rules: {} };
 const recommendedConfig: FlatConfig.Config = {
+  name: 'sonarjs/recommended',
   plugins: {
     sonarjs: {
       rules,


### PR DESCRIPTION
ESLint [recommends](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions) a name for flat configs.

Tools like https://github.com/eslint/config-inspector can use this to indicate the source of rules.

This PR adds that `name` to the current (flat) config. (It is not possible to add a name to the legacy config as it will err there.)